### PR TITLE
HAS-141: replace maven-settings-xml-action and fix Maven auth in release.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,11 +2,12 @@ name: CI
 
 on:
   push:
-    branches: [feature/**]
-  pull_request:
-    branches: [main]
-    types: [ opened ]
+    branches: [main, 'feature/**']
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -16,22 +17,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: maven-settings-xml-action
-        uses: whelk-io/maven-settings-xml-action@v21
-        with:
-          servers: >
-            [
-              {
-                "id": "github-prv",
-                "username": "${{secrets.GH_PRV_USERNAME}}",
-                "password": "${{secrets.GH_PRV_PASSWORD}}"
-              },
-              {
-                "id": "github-org-smart-home",
-                "username": "${{secrets.GH_PRV_USERNAME}}",
-                "password": "${{secrets.GH_PRV_PASSWORD}}"
-              }
-            ]
+      - name: Configure Maven settings for GitHub Packages
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml <<'XML'
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+            <servers>
+              <server>
+                <id>github-prv</id>
+                <username>${env.GH_PRV_USERNAME}</username>
+                <password>${env.GH_PRV_PASSWORD}</password>
+              </server>
+              <server>
+                <id>github-org-smart-home</id>
+                <username>${env.GH_PRV_USERNAME}</username>
+                <password>${env.GH_PRV_PASSWORD}</password>
+              </server>
+            </servers>
+          </settings>
+          XML
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -42,6 +46,9 @@ jobs:
           overwrite-settings: false
 
       - name: Build with Maven
+        env:
+          GH_PRV_USERNAME: ${{ secrets.GH_PRV_USERNAME }}
+          GH_PRV_PASSWORD: ${{ secrets.GH_PRV_PASSWORD }}
         run: mvn -B package --file pom.xml
 
       - name: Discord notification -> success

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Configure Maven settings for GitHub Packages
         run: |
@@ -38,7 +38,7 @@ jobs:
           XML
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -52,14 +52,14 @@ jobs:
         run: mvn -B package --file pom.xml
 
       - name: Discord notification -> success
-        uses: sarisia/actions-status-discord@v1
+        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1.16.0
         if: ${{ success() }}
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           status: ${{ job.status }}
           title: "CI api-gateway-service - success"
       - name: Discord notification -> non-success
-        uses: sarisia/actions-status-discord@v1
+        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1.16.0
         if: ${{ !success() }}
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}


### PR DESCRIPTION
`whelk-io/maven-settings-xml-action` runs on the deprecated **Node 20** runtime and has had
no release since February 2024 — unlike the Docker actions in HAS-140, it cannot be fixed by
a version bump. It is replaced by a plain `run:` step that writes `~/.m2/settings.xml`
with both GitHub Packages servers.

### `release.yml` never actually authenticated

Three independent defects, all fixed here:

1. `setup-java`'s `server-username`/`server-password` take **environment variable names**;
   the workflow passed the literal `x-access-token` and the interpolated secret value, so
   `settings.xml` ended up with `${env.x-access-token}` — a placeholder Maven cannot resolve.
2. The second step, *Set up Maven settings for organization*, was a **no-op**. With
   `overwrite-settings: false` the action skips generation entirely when the file exists
   ([`src/auth.ts`](https://github.com/actions/setup-java/blob/v5.6.0/src/auth.ts) — it does
   not merge), so `github-org-smart-home` never reached `settings.xml` at all.
3. `GITHUB_TOKEN` cannot read packages from the `magikabdul` account regardless.

Release builds only ever worked because the shared libraries came from the `~/.m2` cache
that `CI.yml` had populated. On a cache miss the release could not resolve
`cholewa-commons` or `smart-home-sdk`.

### The mechanism now used everywhere

The settings step writes both servers with `${env.GH_PRV_USERNAME}` / `${env.GH_PRV_PASSWORD}`
placeholders, every Maven step exports those secrets via `env:`, and `setup-java` keeps
`overwrite-settings: false` so it does not clobber the file. No third-party action, one less
thing to pin.

### Verification (on `ai-service`, cold Maven cache)

| Signal | Result |
|---|---|
| `Cache restored successfully` | 0 — genuinely cold |
| Downloads from `maven.pkg.github.com` | **1014** |
| Shared library | `github-prv: .../cloud/cholewa/cholewa-commons/1.1.0/cholewa-commons-1.1.0.jar` + `.pom` |
| 401 / Unauthorized | 0 |

The mechanism was also proven locally: `mvn help:effective-settings` resolves
`${env.…}` in both `<server>` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Also in this PR

`CI.yml` did not run on push to `main`, and ran **twice** when a PR was opened (`push` +
`pull_request`). Its triggers now match the migrated repos: push on `main` + `feature/**`,
`workflow_dispatch`, plus a concurrency group.
