### PR TITLE
HAS-170: migrate to Java 21 / Spring Boot 4.1.0, drop Eureka and adopt the observability scheme

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: release
+
+on:
+  release:
+    types: [ created ]
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Get tag
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "GIT_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "GIT_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo 'latest')" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Configure Maven settings for GitHub Packages
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml <<'XML'
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+            <servers>
+              <server>
+                <id>github-prv</id>
+                <username>${env.GH_PRV_USERNAME}</username>
+                <password>${env.GH_PRV_PASSWORD}</password>
+              </server>
+              <server>
+                <id>github-org-smart-home</id>
+                <username>${env.GH_PRV_USERNAME}</username>
+                <password>${env.GH_PRV_PASSWORD}</password>
+              </server>
+            </servers>
+          </settings>
+          XML
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+          overwrite-settings: false
+
+      - name: Set project version
+        env:
+          GH_PRV_USERNAME: ${{ secrets.GH_PRV_USERNAME }}
+          GH_PRV_PASSWORD: ${{ secrets.GH_PRV_PASSWORD }}
+        run: mvn versions:set -DnewVersion=${{ steps.version.outputs.GIT_TAG }}
+
+      - name: Build with Maven
+        env:
+          GH_PRV_USERNAME: ${{ secrets.GH_PRV_USERNAME }}
+          GH_PRV_PASSWORD: ${{ secrets.GH_PRV_PASSWORD }}
+        run: mvn -B package -DskipTests --file pom.xml
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: magikabdul/api-gateway-service
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ steps.version.outputs.GIT_TAG }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,85 @@
+name: SonarQube
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  build:
+    name: Build and analyze
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+
+      - name: Configure Maven settings for GitHub Packages
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml <<'XML'
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+            <servers>
+              <server>
+                <id>github-prv</id>
+                <username>${env.GH_PRV_USERNAME}</username>
+                <password>${env.GH_PRV_PASSWORD}</password>
+              </server>
+              <server>
+                <id>github-org-smart-home</id>
+                <username>${env.GH_PRV_USERNAME}</username>
+                <password>${env.GH_PRV_PASSWORD}</password>
+              </server>
+            </servers>
+          </settings>
+          XML
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          java-version: 21
+          distribution: 'temurin' # Unified with CI.yml
+          cache: maven
+          overwrite-settings: false
+
+      - name: Cache SonarQube packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Build and test with JaCoCo
+        env:
+          GH_PRV_USERNAME: ${{ secrets.GH_PRV_USERNAME }}
+          GH_PRV_PASSWORD: ${{ secrets.GH_PRV_PASSWORD }}
+        run: mvn clean org.jacoco:jacoco-maven-plugin:0.8.12:prepare-agent test org.jacoco:jacoco-maven-plugin:0.8.12:report
+
+      - name: Build and analyze
+        env:
+          GH_PRV_USERNAME: ${{ secrets.GH_PRV_USERNAME }}
+          GH_PRV_PASSWORD: ${{ secrets.GH_PRV_PASSWORD }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -DskipTests
+
+      - name: SonarQube Quality Gate check
+        id: sonar
+        uses: SonarSource/sonarqube-quality-gate-action@cf038b0e0cdecfa9e56c198bbb7d21d751d62c3b # v1.2.0
+        timeout-minutes: 5
+        continue-on-error: true
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          scanMetadataReportFile: target/sonar/report-task.txt
+
+      - name: Comment PR with SonarQube results
+        if: github.event_name == 'pull_request' && steps.sonar.outcome == 'failure'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '⚠️ **SonarQube Quality Gate failed**\n\nCheck the details in [SonarCloud](https://sonarcloud.io/project/configuration/GitHubActions?id=smart-home-automation-system_api-gateway-service)'
+            })

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@ FROM amd64/eclipse-temurin:21.0.6_7-jdk-alpine AS builder
 WORKDIR /application
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
-RUN java -Djarmode=layertools -jar application.jar extract
+RUN java -Djarmode=tools -jar application.jar extract --layers --destination extracted
 
 FROM amd64/eclipse-temurin:21.0.6_7-jdk-alpine
 WORKDIR /application
-COPY --from=builder application/dependencies/ ./
-COPY --from=builder application/spring-boot-loader/ ./
-COPY --from=builder application/snapshot-dependencies/ ./
-COPY --from=builder application/application/ ./
+COPY --from=builder /application/extracted/dependencies/ ./
+COPY --from=builder /application/extracted/spring-boot-loader/ ./
+COPY --from=builder /application/extracted/snapshot-dependencies/ ./
+COPY --from=builder /application/extracted/application/ ./
 
 RUN apk add --no-cache tzdata
 ENV TZ="Europe/Warsaw"
@@ -17,5 +17,5 @@ ENV TZ="Europe/Warsaw"
 VOLUME /tmp
 USER nobody:nobody
 
-ENTRYPOINT ["java", "-XshowSettings:vm", "-XX:+UseZGC", "-XX:MaxRAMPercentage=75.0", "org.springframework.boot.loader.launch.JarLauncher"]
-EXPOSE 6200 9200
+ENTRYPOINT ["java", "-XshowSettings:vm", "-XX:+UseZGC", "-XX:MaxRAMPercentage=75.0", "-jar", "application.jar"]
+EXPOSE 6200 8200

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # api-gateway-service
 
-Gateway to other home-automation services. 
+Gateway to other home-automation services.
 
 [![CI](https://github.com/smart-home-automation-system/api-gateway-service/actions/workflows/CI.yml/badge.svg)](https://github.com/smart-home-automation-system/api-gateway-service/actions/workflows/CI.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=smart-home-automation-system_api-gateway-service&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=smart-home-automation-system_api-gateway-service)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=smart-home-automation-system_api-gateway-service&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=smart-home-automation-system_api-gateway-service)
+
 ![GitHub Release Date - Published_At](https://img.shields.io/github/release-date/smart-home-automation-system/api-gateway-service?style=plastic)
 ![GitHub Release](https://img.shields.io/github/v/release/smart-home-automation-system/api-gateway-service?style=plastic)
 
@@ -10,7 +13,9 @@ Gateway to other home-automation services.
 
 ![GitHub top language](https://img.shields.io/github/languages/top/smart-home-automation-system/api-gateway-service?style=plastic)
 ![Java](https://img.shields.io/badge/java-21-yellow?style=plastic)
-![SpringBoot](https://img.shields.io/badge/SpringBoot-3.5.0-blue?style=plastic)
+![SpringBoot](https://img.shields.io/badge/SpringBoot-4.1.0-blue?style=plastic)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=smart-home-automation-system_api-gateway-service&metric=coverage)](https://sonarcloud.io/summary/new_code?id=smart-home-automation-system_api-gateway-service)
+[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=smart-home-automation-system_api-gateway-service&metric=ncloc)](https://sonarcloud.io/summary/new_code?id=smart-home-automation-system_api-gateway-service)
 
 ![GitHub issues](https://img.shields.io/github/issues/smart-home-automation-system/api-gateway-service?style=plastic)
 ![GitHub contributors](https://img.shields.io/github/contributors/smart-home-automation-system/api-gateway-service?style=plastic)
@@ -18,3 +23,61 @@ Gateway to other home-automation services.
 
 ![GitHub last commit](https://img.shields.io/github/last-commit/smart-home-automation-system/api-gateway-service?style=plastic)
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/m/smart-home-automation-system/api-gateway-service?style=plastic)
+
+---
+
+# Description
+
+Spring Cloud Gateway sitting at the edge of the cluster: the k8s ingress hands it the external
+traffic under `/home` and it forwards to the internal services over k8s DNS. It is also where a
+request's trace starts, so one `traceId` follows it through every service it touches.
+
+Routing is **static** — service discovery was retired together with `service-discovery` (Eureka),
+and k8s DNS resolves the targets. Each route's host and port come from the `internal.service.*`
+configuration group.
+
+## Spring Cloud on Boot 4.1 — accepted risk
+
+No Spring Cloud release train targets Spring Boot 4.1 (2025.1.2, the newest, is built against
+Boot 4.0.7), so the BOM is not imported and `spring-cloud-starter-gateway-server-webflux` is
+pinned on its own (`spring-cloud-gateway.version`). The combination works because Boot 4.1.0 and
+4.0.7 sit on the same Spring Framework 7.0.x line, and it is verified on every change — but it is
+outside Spring's compatibility matrix, so **re-test the gateway after any bump** of either version.
+
+## Run locally
+
+```bash
+mvn verify                                  # build and tests
+mvn spring-boot:run -Dspring-boot.run.profiles=home,local
+```
+
+| | Application | Actuator |
+|---|---|---|
+| local (`local` profile) | 6200 | 8200 |
+| cluster (`home` profile) | 6200 | 8200 |
+
+The `local` profile points the routes at `localhost` instead of the k8s service names; the
+Actuator exposes `health`, `info` and `prometheus`.
+
+## Routes
+
+Base path `/home` (`spring.webflux.base-path`), so route predicates are written without it.
+
+| Path | Target | State |
+|---|---|---|
+| `/home/water/hot` (GET) | `water-service` | **dead** — the service exposes no such path |
+| `/home/water/management` | `water-service` | **dead** — the service exposes no such path |
+
+Both routes predate this migration and point at paths `water-service` never had: it serves
+`/home/water/status/active` and `/home/water/status/temperature` (its own README records the
+mismatch). Nothing regressed here — the discovery locator that was removed would not have covered
+them either — but until HAS-171 rewrites the routing, `water-service` stays unreachable from
+outside the cluster, and so do the services the ingress does not route directly.
+
+Anything not matched by a route returns 404; a route whose target is down returns 502 with a fixed
+message, deliberately without the internal host and port (see `UpstreamUnavailableProcessor`).
+
+One trap for whoever writes the new routes: the path part of a route's `uri(...)` is **discarded**
+— `RouteToRequestUrlFilter` merges only scheme, host and port onto the incoming request URI. The
+current routes appear to work only because the appended path equals the incoming one. Changing the
+target path needs a `rewritePath` / `setPath` filter, not a longer URI string.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.0</version>
+		<version>4.1.0</version>
 		<relativePath/>
 		<!-- lookup parent from repository -->
 	</parent>
@@ -16,43 +16,42 @@
 
 	<name>api-gateway-service</name>
 	<description>api-gateway-service</description>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-
-	<developers>
-		<developer/>
-	</developers>
-
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
 
 	<properties>
 		<java.version>21</java.version>
-		<logbook.version>3.11.0</logbook.version>
-		<spring-cloud.version>2025.0.0-RC1</spring-cloud.version>
+		<!-- default empty; jacoco:prepare-agent overrides it in the sonar workflow -->
+		<argLine/>
+
+		<sonar.organization>smart-home-automation-system</sonar.organization>
+		<sonar.projectKey>smart-home-automation-system_api-gateway-service</sonar.projectKey>
+		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
+
+		<apiguardian.version>1.1.2</apiguardian.version>
+		<logbook.version>4.0.4</logbook.version>
+		<!-- Spring Cloud ships no release train for Boot 4.1 (2025.1.2, the newest, is built
+		     against Boot 4.0.7), so the BOM is gone and the starter is pinned on its own. The
+		     pairing holds because Boot 4.1.0 and 4.0.7 sit on the same Spring Framework 7.0.x -
+		     verified by hand, but outside Spring's compatibility matrix: re-test on every bump -->
+		<spring-cloud-gateway.version>5.0.2</spring-cloud-gateway.version>
+
 		<!--  internal dependencies versions-->
-		<cholewa-commons.version>0.1.2</cholewa-commons.version>
+		<cholewa-commons.version>1.3.1</cholewa-commons.version>
+
 		<!--  plugins versions-->
-		<maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
-		<maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
+		<maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
+		<maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
 		<tidy-maven-plugin.version>1.4.0</tidy-maven-plugin.version>
-		<versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
+		<versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
 	</properties>
 
 	<dependencyManagement>
 		<dependencies>
+			<!-- logbook 4.0.4 pulls 1.1.1, JUnit 6 pulls 1.1.2; pinned so dependencyConvergence
+			     passes without excluding the annotations javac needs to read logbook's class files -->
 			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-dependencies</artifactId>
-				<version>${spring-cloud.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
+				<groupId>org.apiguardian</groupId>
+				<artifactId>apiguardian-api</artifactId>
+				<version>${apiguardian.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -67,21 +66,43 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-gateway-server-webflux</artifactId>
+			<version>${spring-cloud-gateway.version}</version>
+		</dependency>
+
+		<!-- required by logbook's WebFluxNettyClientConfiguration; logbook declares it optional -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-http-client</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.zalando</groupId>
 			<artifactId>logbook-spring-boot-webflux-autoconfigure</artifactId>
 			<version>${logbook.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.apiguardian</groupId>
-					<artifactId>apiguardian-api</artifactId>
-				</exclusion>
-			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<!-- tracing: the Boot module carries BraveAutoConfiguration, the bridge the Brave
+		     implementation it is conditional on; no exporter, the trace lives in the logs -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-micrometer-tracing-brave</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-tracing-bridge-brave</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>
@@ -98,14 +119,6 @@
 
 	<repositories>
 		<repository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-		<repository>
 			<id>github-prv</id>
 			<url>https://maven.pkg.github.com/magikabdul/*</url>
 		</repository>
@@ -118,8 +131,49 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.springframework.boot</groupId>
+							<artifactId>spring-boot-configuration-processor</artifactId>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>properties</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>${maven-surefire-plugin.version}</version>
+				<configuration>
+					<argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar} -Xshare:off</argLine>
+					<!-- the test document of application.yaml switches the console logs back to plain
+					     text and logbook to http style; without this only a class carrying
+					     @ActiveProfiles would get it and the rest would log logstash JSON -->
+					<systemPropertyVariables>
+						<spring.profiles.active>test</spring.profiles.active>
+					</systemPropertyVariables>
+					<includes>
+						<include>**/*Test.java</include>
+						<include>**/*IT.java</include>
+					</includes>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -158,6 +212,9 @@
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>versions-maven-plugin</artifactId>
 				<version>${versions-maven-plugin.version}</version>
+				<configuration>
+					<ignoredVersions>(?i).*(beta|milestone|rc|alpha|snapshot|preview|m\d+|b\d+).*</ignoredVersions>
+				</configuration>
 				<executions>
 					<execution>
 						<goals>

--- a/src/main/java/cloud/cholewa/gateway/config/ExceptionHandlerConfig.java
+++ b/src/main/java/cloud/cholewa/gateway/config/ExceptionHandlerConfig.java
@@ -1,13 +1,15 @@
 package cloud.cholewa.gateway.config;
 
 import cloud.cholewa.commons.error.GlobalErrorExceptionHandler;
+import cloud.cholewa.gateway.error.UpstreamUnavailableProcessor;
 import org.springframework.boot.autoconfigure.web.WebProperties;
-import org.springframework.boot.web.reactive.error.ErrorAttributes;
+import org.springframework.boot.webflux.error.ErrorAttributes;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.codec.ServerCodecConfigurer;
 
+import java.net.ConnectException;
 import java.util.Map;
 
 @Configuration
@@ -24,9 +26,11 @@ public class ExceptionHandlerConfig {
             errorAttributes, webProperties.getResources(), applicationContext, serverCodecConfigurer
         );
 
-        globalErrorExceptionHandler.withCustomErrorProcessor(Map.ofEntries(
-
-        ));
+        globalErrorExceptionHandler.withCustomErrorProcessor(
+            Map.ofEntries(
+                Map.entry(ConnectException.class, new UpstreamUnavailableProcessor())
+            )
+        );
 
         return globalErrorExceptionHandler;
     }

--- a/src/main/java/cloud/cholewa/gateway/error/UpstreamUnavailableProcessor.java
+++ b/src/main/java/cloud/cholewa/gateway/error/UpstreamUnavailableProcessor.java
@@ -1,0 +1,34 @@
+package cloud.cholewa.gateway.error;
+
+import cloud.cholewa.commons.error.model.ErrorMessage;
+import cloud.cholewa.commons.error.model.Errors;
+import cloud.cholewa.commons.error.processor.ExceptionProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+
+import java.util.Collections;
+
+//the gateway is the only service reachable from outside, so what it puts in "details" leaves the
+//cluster - and since the cluster logs are JSON, it is stored and searchable as well. The default
+//processor would pass the connection error through verbatim, which names the internal host, pod IP
+//and port of the target; only the exception type is logged and the caller gets a fixed message
+public class UpstreamUnavailableProcessor implements ExceptionProcessor {
+
+    private static final Logger log = LoggerFactory.getLogger(UpstreamUnavailableProcessor.class);
+
+    @Override
+    public Errors apply(final Throwable throwable) {
+
+        log.error("Upstream service unreachable [{}]", throwable.getClass().getSimpleName());
+
+        return Errors.builder()
+            .httpStatus(HttpStatus.BAD_GATEWAY)
+            .errors(Collections.singleton(
+                ErrorMessage.builder()
+                    .message("Upstream service unavailable")
+                    .build()
+            ))
+            .build();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,25 +1,35 @@
 spring:
-  application.name: api-gateway-service
+  application:
+    name: api-gateway-service
+    version: @project.version@
   profiles:
     active: home
-  cloud:
-    gateway:
-      discovery:
-        locator:
-          enabled: true
-          lower-case-service-id: true
   webflux:
     base-path: /home
+  reactor:
+    # default LIMITED restores ThreadLocals only in "tap" and "handle", so traceId would be
+    # missing from the MDC of every log statement inside a reactive chain
+    context-propagation: auto
 
 server:
   port: 6200
-
-eureka:
-  client:
-    service-url:
-      defaultZone: http://service-discovery:6000/eureka
-    fetch-registry: true
-    register-with-eureka: true
+management:
+  server:
+    port: 8200
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  tracing:
+    sampling:
+      # default 0.1; a home system generates so little traffic that sampling everything is free,
+      # and a partially sampled trace is useless when it is the only record of a request.
+      # This service opens the trace every external request is then followed by
+      probability: 1.0
 
 internal:
   service:
@@ -31,9 +41,12 @@ internal:
 
 logbook:
   format:
-    style: http
+    style: json
 
 logging:
+  structured:
+    format:
+      console: logstash
   level:
     org.zalando.logbook: trace
 
@@ -44,11 +57,6 @@ spring:
     activate:
       on-profile: local
 
-eureka:
-  client:
-    service-url:
-      defaultZone: http://localhost:6000/eureka
-
 internal:
   service:
     water:
@@ -56,3 +64,28 @@ internal:
         scheme: http
         host: localhost
         port: 6006
+
+logbook:
+  format:
+    style: http
+
+logging:
+  structured:
+    format:
+      console: ""
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: test
+
+logbook:
+  format:
+    style: http
+
+logging:
+  structured:
+    format:
+      console: ""

--- a/src/test/java/cloud/cholewa/gateway/ApiGatewayServiceApplicationTest.java
+++ b/src/test/java/cloud/cholewa/gateway/ApiGatewayServiceApplicationTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class ApiGatewayServiceApplicationTests {
+class ApiGatewayServiceApplicationTest {
 
     @Test
     void contextLoads() {

--- a/src/test/java/cloud/cholewa/gateway/error/UpstreamUnavailableProcessorTest.java
+++ b/src/test/java/cloud/cholewa/gateway/error/UpstreamUnavailableProcessorTest.java
@@ -1,0 +1,35 @@
+package cloud.cholewa.gateway.error;
+
+import cloud.cholewa.commons.error.model.ErrorMessage;
+import cloud.cholewa.commons.error.model.Errors;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import java.net.ConnectException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UpstreamUnavailableProcessorTest {
+
+    private final UpstreamUnavailableProcessor sut = new UpstreamUnavailableProcessor();
+
+    @Test
+    void should_answer_with_bad_gateway() {
+        Errors errors = sut.apply(new ConnectException("Connection refused: getsockopt: water-service/10.96.0.7:6200"));
+
+        assertThat(errors.getHttpStatus()).isEqualTo(HttpStatus.BAD_GATEWAY);
+        assertThat(errors.getErrors()).hasSize(1);
+    }
+
+    //the gateway is the only service reachable from outside, so the internal host, pod IP and port
+    //the connection error carries must not reach the caller - nor the JSON cluster logs
+    @Test
+    void should_not_leak_the_upstream_address() {
+        Errors errors = sut.apply(new ConnectException("Connection refused: getsockopt: water-service/10.96.0.7:6200"));
+
+        ErrorMessage error = errors.getErrors().iterator().next();
+
+        assertThat(error.getMessage()).isEqualTo("Upstream service unavailable");
+        assertThat(error.getDetails()).isNull();
+    }
+}


### PR DESCRIPTION
The last repo on Spring Boot 3.5.0 and the last Spring Cloud consumer. Since `service-discovery`
was archived and deleted from the cluster, the Eureka client here hammered a server that no longer
exists — a failed heartbeat every 30 s — and the discovery locator resolved nothing.

## Spring Cloud on Boot 4.1 — an accepted risk, not an accident

No Spring Cloud release train targets Boot 4.1: the newest, **2025.1.2, is built against Boot
4.0.7**. So the BOM import is gone — it pinned `2025.0.0-RC1`, a *release candidate*, which is also
why `spring-milestones` was in the pom — and `spring-cloud-starter-gateway-server-webflux` is
pinned on its own at **5.0.2**.

The pairing was verified by hand before this work started, in a throwaway project: the context comes
up, a matched route proxies, an unmatched path 404s. It holds because Boot 4.1.0 and 4.0.7 sit on
the same Spring Framework 7.0.x line. It is outside Spring's compatibility matrix, so **re-test the
gateway on every bump of either version** — the README says so, and `organization.md` records it.

## Migration

- `spring-boot-starter-parent` 3.5.0 → **4.1.0**, Java stays 21
- Eureka client, the `eureka:` blocks and `spring.cloud.gateway.discovery.locator` all removed
- `cholewa-commons` 0.1.2 → **1.3.1** (`ErrorAttributes` moved package in Boot 4), logbook 3.11.0 →
  **4.0.4** without the apiguardian exclusion — pinned in `dependencyManagement` instead
- `Dockerfile`: `-Djarmode=tools … extract --layers`, `-jar application.jar`, `EXPOSE 6200 8200`
  (was `layertools` and 9200)
- pom hygiene: empty Initializr blocks dropped, surefire and `maven-dependency-plugin properties` added

## Observability

Actuator on 8200 with `health,info,prometheus`, probes pinned on, logstash JSON console logs with
plain-text overrides in `local` and `test`, Prometheus registry, Brave tracing with no exporter.
The gateway is where a request's trace now starts.

## Missing CI

`release.yml` and `sonar.yml` never existed here — the 0.0.1 and 0.0.2 images were built outside CI.
Both arrive in the reference shape (SHA-pinned, Sonar quality gate + PR comment). **Needs the
SonarCloud project imported and `SONAR_TOKEN` set on the repo**, otherwise the Sonar job fails as it
did for `shelly-cloud-service`.

## Review findings fixed here

- An empty processor map meant a downstream outage answered the caller with `500` and the raw
  `Connection refused: … host:port` as `details` — the internal name and port of the target, leaving
  the cluster and, from this change on, stored in Loki as searchable JSON.
  `UpstreamUnavailableProcessor` maps it to a fixed **502** and logs only the exception type — the
  treatment `ai-service` got in HAS-165. Verified locally: `502 {"errors":[{"message":"Upstream
  service unavailable"}]}`.
- The test class was named `...Tests`, which the surefire `includes` added here do not match — it
  would have silently stopped running. Renamed to `...Test`.

## Not fixed here — moved to HAS-171

The water routes stay untouched and stay broken: they target `/water/hot` and `/water/management`,
paths `water-service` does not expose (it serves `/home/water/status/{active,temperature}`; its own
README records the mismatch). That predates this change and the removed discovery locator would not
have covered them either. The README now states it plainly, and HAS-171 was updated with the finding
plus one trap for whoever writes the new routes: **the path part of a route's `uri(...)` is
discarded** — `RouteToRequestUrlFilter` merges only scheme, host and port onto the incoming URI.

## Verification

- `mvn clean verify` green; dependency tree free of Eureka, the Spring Cloud BOM and Jackson 2
  (beyond the allowed annotation package)
- runs locally on `home,local`: `/actuator/health/{readiness,liveness}` UP on 8200, 89 metrics,
  a route proxies, an unmatched path 404s, `traceId`/`spanId` in the log MDC

`deployment-tools` (private) carries the manifest — `-jar application.jar`, 6200/8200, probes,
scrape annotations — and drops the `!= \`DiscoveryClient\`` filter from the "Error log spike" alert,
which existed only to hide this service's Eureka heartbeat noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
